### PR TITLE
Publish Maven Central

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,13 @@ jobs:
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to Maven Central
+on:
+  workflow_dispatch:
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Publish
+        run: ./gradlew publishAndReleaseToMavenCentral
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,6 +20,31 @@ Korean Utils는 한글 텍스트를 처리하고 조작하기 위한 Java 라이
 - 한글 텍스트에 대한 N-gram 생성
 - 한글 문자 길이를 고려한 길이 계산
 
+## Installation
+
+Maven이나 Gradle을 사용하여 프로젝트에 이 라이브러리를 포함할 수 있습니다.
+
+### Maven
+
+`pom.xml`에 아래 의존성을 추가하세요.
+
+```xml
+
+<dependency>
+    <groupId>io.github.crizin</groupId>
+    <artifactId>korean-utils</artifactId>
+    <version>0.0.1</version>
+</dependency>
+```
+
+### Gradle
+
+`build.gradle`에 아래 의존성을 추가하세요.
+
+```groovy
+implementation 'io.github.crizin:korean-utils:0.0.1'
+```
+
 ## 사용법
 
 ### KoreanCharacter

--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ and various other operations useful for processing Korean text.
 - N-gram generation for Korean text
 - Length calculation considering Korean character width
 
+## Installation
+
+You can include this library in your project using Maven or Gradle.
+
+### Maven
+
+Add the following dependency to your `pom.xml`:
+
+```xml
+
+<dependency>
+    <groupId>io.github.crizin</groupId>
+    <artifactId>korean-utils</artifactId>
+    <version>0.0.1</version>
+</dependency>
+```
+
+### Gradle
+
+Add the following dependency to your build.gradle:
+
+```groovy
+implementation 'io.github.crizin:korean-utils:0.0.1'
+```
+
 ## Usage
 
 ### KoreanCharacter

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,16 @@
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
-	id("java")
+	id("java-library")
 	id("jacoco")
 	id("org.sonarqube") version "4.4.1.3373"
+	id("com.vanniktech.maven.publish") version "0.29.0"
 }
 
 group = "io.github.crizin"
-version = "1.0.0"
+version = "0.0.1"
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8
@@ -31,6 +36,52 @@ sonar {
 		property("sonar.projectKey", "crizin_korean-utils")
 		property("sonar.organization", "crizin")
 		property("sonar.host.url", "https://sonarcloud.io")
+	}
+}
+
+mavenPublishing {
+	signAllPublications()
+	publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+	coordinates(
+		groupId = "io.github.crizin",
+		artifactId = "korean-utils",
+		version = "0.0.1",
+	)
+
+	configure(
+		JavaLibrary(
+			javadocJar = JavadocJar.Javadoc(),
+			sourcesJar = true,
+		)
+	)
+
+	pom {
+		name.set("Korean Utils")
+		description.set("A Java library that provides various utility functions for processing and manipulating Korean text")
+		inceptionYear.set("2024")
+		url.set("https://github.com/crizin/korean-utils")
+
+		licenses {
+			license {
+				name.set("MIT License")
+				url.set("https://opensource.org/licenses/MIT")
+			}
+		}
+
+		developers {
+			developer {
+				id.set("crizin")
+				name.set("JaeYong Lee")
+				url.set("https://github.com/crizin")
+			}
+		}
+
+		scm {
+			url.set("https://github.com/crizin/korean-utils")
+			connection.set("scm:git:git://github.com/crizin/korean-utils.git")
+			developerConnection.set("scm:git:ssh://git@github.com/crizin/korean-utils.git")
+		}
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - GitHub Actions 워크플로우에 Maven Central에 게시하는 기능이 추가되었습니다.
- **문서**
  - `README.md` 및 `README.ko.md`에 Maven과 Gradle을 사용한 라이브러리 설치 지침이 추가되었습니다.
- **작업**
  - GitHub Actions 워크플로우에서 `actions/checkout` 및 `actions/setup-java`의 버전이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->