### PR TITLE
Adding the --scan option to gradle build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
 jobs:
   build:
     name: Build and analyze
@@ -39,4 +40,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build sonar jacocoTestReport --info
+        run: ./gradlew build sonar jacocoTestReport --info --scan


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - `workflow_dispatch` 트리거를 추가하여 워크플로 수동 실행 기능 도입.
  - `./gradlew` 명령어에 `--scan` 옵션을 추가하여 빌드 스캔 기능 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->