### PR TITLE
Correct variable names and upgrade Junit version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-	testImplementation(platform("org.junit:junit-bom:5.10.2"))
+	testImplementation(platform("org.junit:junit-bom:5.10.3"))
 	testImplementation("org.junit.jupiter:junit-jupiter")
 	testImplementation("org.assertj:assertj-core:3.26.0")
 }

--- a/src/main/java/io/github/crizin/Jamo.java
+++ b/src/main/java/io/github/crizin/Jamo.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  *     used mainly for compatibility with older encodings and standards.</li>
  * </ul>
  *
- * <p>For example, the Korean character "한" is composed of a Chosung("ㅎ"), a Jungseong ("ㅏ"), and a Jongsung ("ㄴ").</p>
+ * <p>For example, the Korean character "한" is composed of a Choseong("ㅎ"), a Jungseong ("ㅏ"), and a Jongseong ("ㄴ").</p>
  *
  * <h2>Limit of this interface</h2>
  *

--- a/src/main/java/io/github/crizin/KoreanUtils.java
+++ b/src/main/java/io/github/crizin/KoreanUtils.java
@@ -465,10 +465,10 @@ public class KoreanUtils {
 			Jamo.Jongseong suffixJongseong = suffixChar.getJongseong();
 
 			if (suffixChoseong != null && suffixChar.getJungseong() == null && suffixJongseong == null) {
-				Jamo.Jongseong candidateJongsung = Jamo.Jongseong.find(suffixChoseong.getCompatibilityJamo());
+				Jamo.Jongseong candidateJongseong = Jamo.Jongseong.find(suffixChoseong.getCompatibilityJamo());
 
-				if (candidateJongsung != null) {
-					suffixJongseong = candidateJongsung;
+				if (candidateJongseong != null) {
+					suffixJongseong = candidateJongseong;
 					suffixChoseong = null;
 				}
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
	- 'Chosung'을 'Choseong'으로, 'Jongsung'을 'Jongseong'으로 문서 오류 수정

- **버그 수정**
	- `KoreanUtils` 클래스의 `endsWith` 메서드에서 변수 이름 `candidateJongsung`을 `candidateJongseong`으로 수정

- **작업**
	- JUnit BOM 버전을 `5.10.2`에서 `5.10.3`으로 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->