### PR TITLE
Remove SonarCloud integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,6 @@ jobs:
           java-version: 21
           distribution: temurin
 
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:
@@ -42,5 +35,4 @@ jobs:
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build sonar jacocoTestReport --info --scan
+        run: ./gradlew build --info --scan

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,8 +4,6 @@
 
 [![Build](https://github.com/crizin/korean-utils/actions/workflows/build.yml/badge.svg)](https://github.com/crizin/korean-utils/actions)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/274ee8e6cb014384b35cc6e4a3b82718)](https://app.codacy.com/gh/crizin/korean-utils/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=crizin_korean-utils&metric=alert_status)](https://sonarcloud.io/summary/overall?id=crizin_korean-utils)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=crizin_korean-utils&metric=coverage)](https://sonarcloud.io/summary/overall?id=crizin_korean-utils)
 [![License: MIT](https://img.shields.io/github/license/crizin/korean-utils)](https://opensource.org/licenses/MIT)
 
 Korean Utils는 한글 텍스트를 처리하고 조작하기 위한 Java 라이브러리입니다.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![Build](https://github.com/crizin/korean-utils/actions/workflows/build.yml/badge.svg)](https://github.com/crizin/korean-utils/actions)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/274ee8e6cb014384b35cc6e4a3b82718)](https://app.codacy.com/gh/crizin/korean-utils/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=crizin_korean-utils&metric=alert_status)](https://sonarcloud.io/summary/overall?id=crizin_korean-utils)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=crizin_korean-utils&metric=coverage)](https://sonarcloud.io/summary/overall?id=crizin_korean-utils)
 [![License: MIT](https://img.shields.io/github/license/crizin/korean-utils)](https://opensource.org/licenses/MIT)
 
 Korean Utils is a Java library for handling and manipulating Korean text. It provides utility classes for working with Korean characters,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
 	id("java-library")
 	id("jacoco")
-	id("org.sonarqube") version "4.4.1.3373"
 	id("com.vanniktech.maven.publish") version "0.29.0"
 }
 
@@ -29,14 +28,6 @@ dependencies {
 
 jacoco {
 	toolVersion = "0.8.12"
-}
-
-sonar {
-	properties {
-		property("sonar.projectKey", "crizin_korean-utils")
-		property("sonar.organization", "crizin")
-		property("sonar.host.url", "https://sonarcloud.io")
-	}
 }
 
 mavenPublishing {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- SonarCloud 메트릭 관련 배지 링크(품질 게이트 상태 및 커버리지 배지)를 README 파일에서 제거했습니다.
  
- **문서화**
	- README 파일의 시각적 요소를 간소화하여 표시되는 배지 수를 줄였습니다.

- **리팩토링**
	- 빌드 프로세스에서 SonarQube 플러그인 및 관련 구성 요소를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->